### PR TITLE
Show BrowseHappy notice for browsers < IE9

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -21,7 +21,7 @@
     <link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-rc.1/css/select2.min.css" rel="stylesheet" />
   </head>
   <body ng-app="edudashApp">
-    <!--[if lt IE 7]>
+    <!--[if lt IE 9]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
 


### PR DESCRIPTION
Since AngularJS only supports IE9+, the oudated browser warning should be shown for IE < 9  instead of IE < 7.

for TSD-37
