### PR TITLE
Use wiredep to include the highcharts gauge

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,6 +162,14 @@ module.exports = function (grunt) {
               'dist/leaflet-src.js',
               'dist/leaflet.css'
             ]
+          },
+          'highcharts': {
+            'main': [
+              'highcharts.js',
+              'highcharts-more.js',
+              'modules/exporting.js',
+              'modules/solid-gauge.js'
+            ]
           }
         }
       }


### PR DESCRIPTION
so that our build doesn't clobber it from index.html.

@esoliani we can add stuff to this overrides section of the `wiredep` config to change which scripts get included in the `<!-- bower:js -->` section of index.html. The build rewrites that whole block based on the `bower.json` files in our bower dependencies and this overrides config.
