### PR TITLE
Emphasize overlay edges

### DIFF
--- a/app/styles/_flyout.scss
+++ b/app/styles/_flyout.scss
@@ -5,8 +5,8 @@
   bottom: $bottom-bar-height + 1px;
   width: $flyout-width;
   padding: 15px 30px;
-  background: hsla(0, 0%, 97%, 0.9);
-  border-left: 1px solid hsla(0, 0%, 85%, 0.5);
+  background: $map-overlay;
+  box-shadow: $map-overlay-outline;
   overflow-y: auto;
   .has-filters & {
     bottom: ($bottom-bar-height + 1px) * 2;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -12,7 +12,9 @@ $rank-poor: #f56053;
 
 $unknown: #aaa;
 
-$map-overlay: hsla(0, 0%, 97%, 0.9);
+$map-overlay: hsla(0, 0%, 100%, 0.9);
+$map-overlay-edge: hsla(0, 0%, 0%, 0.1);
+$map-overlay-outline: -1px -1px 0 $map-overlay-edge;
 
 // Layout
 

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -931,6 +931,7 @@ map-bottom-toggle {
   header {
     height: $bottom-bar-height;
     background: $map-overlay;
+    box-shadow: $map-overlay-outline;
     text-align: center;
     h3 {
       font-size: 1em;
@@ -953,6 +954,7 @@ map-bottom-toggle {
     padding: 5px 1em;
     margin-top: 1px;
     background: $map-overlay;
+    box-shadow: $map-overlay-outline;
     &.closed {
       @include sr-only;
     }


### PR DESCRIPTION
Whiten the overlay backgrounds

Add a subtle dark faded overlay to the 1px gaps, makes them stand
out on light map areas
