### PR TITLE
Bring back some districts stuff

### DIFF
--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -1,4 +1,4 @@
-<div class="map-widget {'has-filters': mapView != 'districts'}">
+<div class="map-widget {'has-filters': mapView != 'district'}">
   <div class="map-position-wrap">
     <div leaflet-map
       id="map"
@@ -217,7 +217,7 @@
             </div>
           </div>
 
-          <div ng-if="mapView=='districts'">
+          <div ng-if="mapView=='district'">
             <div id="districtinfo" class="container-fluid">
               <div class="col-sm-12 performance-nav">
                 <ul class="nav nav-tabs">


### PR DESCRIPTION
Either from a mis-merge or a refactoring mistake, `districts` should always now be `district`
