### PR TITLE
NOT READY FOR MERGE: Canvas Markers

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -48,7 +48,7 @@
 
     <!-- Render maps on canvas! -->
     <script>
-      // window.L_PREFER_CANVAS = true
+      window.L_PREFER_CANVAS = true
     </script>
 
     <!-- build:js(.) scripts/oldieshim.js -->

--- a/app/scripts/controllers/dashboard.coffee
+++ b/app/scripts/controllers/dashboard.coffee
@@ -138,21 +138,15 @@ angular.module('edudashAppCtrl').controller 'DashboardCtrl', [
             if $scope.viewMode == 'schools'
               getSchoolPin(thing.CODE).then (pin) ->
                 pin.bringToFront()
-                pin.setStyle
-                  color: '#05a2dc'
-                  weight: 5
-                  opacity: 1
-                  fillOpacity: 1
+                pin.setRadius 12
+                colorPin thing.CODE, pin, true
             #   when 'regional' then weight: 5, opacity: 1
 
           if oldThing != null
             if $scope.viewMode == 'schools'
               getSchoolPin(oldThing.CODE).then (pin) ->
-                pin.setStyle
-                  color: '#fff'
-                  weight: 2
-                  opacity: 0.5
-                  fillOpacity: 0.6
+                pin.setRadius 8
+                colorPin oldThing.CODE, pin
               # when 'regional' then weight: 0, opacity: 0.6
 
         $scope.$watch 'selected', (school) ->
@@ -303,11 +297,11 @@ angular.module('edudashAppCtrl').controller 'DashboardCtrl', [
               options: options
 
 
-        colorPin = (code, l) -> findSchool(code).then (school) ->
+        colorPin = (code, l, hovered) -> findSchool(code).then (school) ->
           v = switch
             when $scope.visMode == 'passrate' then school.PASS_RATE
             when $scope.visMode == 'ptratio' then school.pt_ratio
-          l.setStyle colorSrv.pinStyle v, $scope.visMode
+          l.setStyle colorSrv.pinStyle v, $scope.visMode, hovered
 
         groupByDistrict = (rows) ->
           districts = {}

--- a/app/scripts/services/colors.coffee
+++ b/app/scripts/services/colors.coffee
@@ -32,9 +32,11 @@ angular.module 'edudashAppSrv'
     colorize: (val, mode) ->
       this.colors[this.categorize val, mode]
 
-    pinStyle: (val, mode) ->
-      color: '#fff'
-      fillOpacity: 0.75
+    pinStyle: (val, mode, hovered) ->
+      weight: if hovered then 6 else 2
+      opacity: 1
+      color: if hovered then '#05a2dc' else '#fff'
+      fillOpacity: 1
       fillColor: this.colorize val, mode
 
     areaStyle: (val, mode) ->


### PR DESCRIPTION
Renders markers on a canvas instead of as SVGs, which improves performance a little bit on FireFox

This branch also makes them opaque:
![2015-07-30-142837_1075x815_scrot](https://cloud.githubusercontent.com/assets/205128/8991555/4dfcd104-36c7-11e5-9191-63bbd5b241f4.png)

but we could revert that and keep the performance win I think.

The main issue is that the markers don't rise to the top when they are hovered, as they do with the SVG markers, so it's not always easy to see which one is hovered. I'm not sure how to fix this, but it may be possible.
