### PR TITLE
DO NOT MERGE: Experiment: Parallelize download

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,9 +31,9 @@
 
     <edu-header></edu-header>
 
-    <div ng-view=""></div>
-
-    <div id="spinner" class="loading ajax-loader"></div>
+    <div ng-view="">
+      <div class="loading ajax-loader"></div>
+    </div>
 
     <!-- Google Analytics -->
     <script>

--- a/app/scripts/app.coffee
+++ b/app/scripts/app.coffee
@@ -22,7 +22,6 @@ angular
     'ui-rangeSlider',
     'i18nEdudashApp',
     'leafletMap',
-    'edudashAppLoading',
     'edudashAppCtrl',
     'edudashAppSrv',
     'edudashAppDir',

--- a/app/scripts/controllers/dashboard.coffee
+++ b/app/scripts/controllers/dashboard.coffee
@@ -114,6 +114,10 @@ angular.module('edudashAppCtrl').controller 'DashboardCtrl', [
           oldPins.then (pins) ->
             leafletData.getMap(mapId).then (map) -> map.removeLayer pins
 
+        $scope.$watch 'schoolMarker', (blah, oldMarker) -> if oldMarker?
+          oldMarker.then (marker) ->
+              leafletData.getMap(mapId).then (map) -> map.removeLayer marker
+
         $scope.$watchGroup ['pins', 'visMode'], ([pinsP]) -> if pinsP?
           pinsP.then (pins) ->
             pins.eachVisibleLayer colorPin
@@ -175,6 +179,7 @@ angular.module('edudashAppCtrl').controller 'DashboardCtrl', [
           $scope.filteredSchools = null
           $scope.pins = null
           $scope.rankedBy = null
+          $scope.schoolMarker = null
 
         setSchool = (school) ->
           latlng = [school.LATITUDE, school.LONGITUDE]
@@ -332,13 +337,13 @@ angular.module('edudashAppCtrl').controller 'DashboardCtrl', [
               l.setStyle colorSrv.areaStyle v, $scope.visMode
 
         markSchool = (latlng) ->
-          unless schoolMarker?
+          unless $scope.schoolMarker?
             icon = layersSrv.awesomeIcon markerColor: 'blue', icon: 'map-marker'
-            schoolMarker = layersSrv.marker 'school-marker', mapId,
+            $scope.schoolMarker = layersSrv.marker 'school-marker', mapId,
               latlng: latlng
               options: icon: icon
 
-          schoolMarker.then (marker) ->
+          $scope.schoolMarker.then (marker) ->
             marker.setLatLng latlng
 
         search = (query) ->

--- a/app/scripts/directives/schoollist.coffee
+++ b/app/scripts/directives/schoollist.coffee
@@ -7,13 +7,13 @@
  # # schoolList
 ###
 angular.module 'edudashApp'
-  .directive 'schoolList', ->
+  .directive 'schoolList', (loadingSrv) ->
     restrict: 'E'
     templateUrl: 'views/schoollist.html'
     scope:
       listTitle: '@listTitle'
       listType: '@type'
-      schools: '=schools'
+      dataset: '=dataset'
       click: '=click'
       hover: '=hover'
       unHover: '=unHover'
@@ -21,3 +21,8 @@ angular.module 'edudashApp'
       max: '=max'
       min: '=min'
       sufix: '@sufix'
+    link: (scope, el, attrs) ->
+      scope.schools = []
+      scope.$watch 'dataset', (p) -> if p?
+        p.then (schools) -> scope.schools = schools
+        loadingSrv.containerLoad p, el[0]

--- a/app/scripts/directives/schoollist.coffee
+++ b/app/scripts/directives/schoollist.coffee
@@ -22,7 +22,10 @@ angular.module 'edudashApp'
       min: '=min'
       sufix: '@sufix'
     link: (scope, el, attrs) ->
-      scope.schools = []
-      scope.$watch 'dataset', (p) -> if p?
-        p.then (schools) -> scope.schools = schools
-        loadingSrv.containerLoad p, el[0]
+      scope.schools = null
+      scope.$watch 'dataset', (p) ->
+        if p?
+          p.then (schools) -> scope.schools = schools
+          loadingSrv.containerLoad p, el[0]
+        else
+          scope.schools = null

--- a/app/scripts/services/loading.coffee
+++ b/app/scripts/services/loading.coffee
@@ -7,19 +7,12 @@
  # # 
  # Factory in the edudashApp.
 ###
-angular.module('edudashAppLoading', [])
-.config(($httpProvider) ->
-    $("#spinner").hide();
-    requestCounter = 0
-    $httpProvider.defaults.transformRequest.push  (data, headersGetter) ->
-      $("#spinner").show()
-      requestCounter++
-      data
-    $httpProvider.defaults.transformResponse.push (data) ->
-      if(requestCounter > 0)
-        requestCounter--
-      if(requestCounter == 0)
-        $("#spinner").hide()
-      data
-
-)
+angular.module('edudashAppSrv').factory 'loadingSrv', ($log) ->
+  containerLoad: (promise, container) ->
+    loader = ($ '<div class="loading ajax-loader"></div>')[0]
+    container.appendChild loader
+    promise
+      .then -> container.removeChild loader
+      .catch (err) ->
+        loader.remove()
+        $log.error err

--- a/app/scripts/services/opendataapi.coffee
+++ b/app/scripts/services/opendataapi.coffee
@@ -68,14 +68,21 @@ angular.module 'edudashAppSrv'
         req = $resource ckanQueryURL
         req.get($params).$promise
 
-      getSchools: ({year, schoolType, moreThan40, subtype}) ->
+      getLocations: ({year, schoolType, moreThan40, subtype}) ->
+        ckanResp $http.get ckanQueryURL, params: sql: "
+          SELECT
+            \"CODE\",
+            \"LATITUDE\",
+            \"LONGITUDE\",
+            \"NAME\"
+          FROM \"#{getTable schoolType, subtype}\"
+          #{getConditions schoolType, moreThan40, year}"
+
+      getDetails: ({year, schoolType, moreThan40, subtype}) ->
         ckanResp $http.get ckanQueryURL, params: sql: "
           SELECT
             \"CODE\",
             \"DISTRICT\",
-            \"NAME\",
-            \"LATITUDE\",
-            \"LONGITUDE\",
             \"PASS_RATE\",
             \"REGION\",
             \"WARD\"

--- a/app/scripts/services/opendataapi.coffee
+++ b/app/scripts/services/opendataapi.coffee
@@ -11,12 +11,7 @@ angular.module 'edudashAppSrv'
 .service 'OpenDataApi', [
     '$http', '$resource', '$log', 'CsvParser', '$location', '$q'
     ($http, $resource, $log, CsvParser, $location, $q) ->
-      # AngularJS will instantiate a singleton by calling "new" on this function
-      regexp = /.*localhost.*/ig
-      corsApi = if regexp.test($location.host()) then 'https://cors-anywhere.herokuapp.com' else 'http:/'
-      apiRoot = '/data.takwimu.org/api/action/'
-#      apiRoot = '/tsd.dgstg.org/api/action/'
-      ckanQueryURL = corsApi + apiRoot + 'datastore_search_sql'
+      ckanQueryURL = '//data.takwimu.org/api/action/datastore_search_sql'
       datasetMapping =
         primary:
           'performance': '3a77adf7-925a-4a62-8c70-5e43f022b874'
@@ -46,18 +41,6 @@ angular.module 'edudashAppSrv'
               reject data
           httpPromise.then parse, reject
 
-      getdata: () ->
-        $params =
-          resource_id: '3221ccb4-3b75-4137-a8bd-471a436ed7a5'
-        req = $resource(corsApi + apiRoot + 'datastore_search')
-        req.get($params).$promise
-
-      getDataset: (id) ->
-        $params =
-          resource_id: id
-        req = $resource(corsApi + apiRoot + 'datastore_search')
-        req.get($params).$promise
-
       getTable = (educationLevel, subtype) ->
         if(subtype?)
           datasetMapping[educationLevel][subtype]
@@ -82,7 +65,7 @@ angular.module 'edudashAppSrv'
       datasetByQuery: (query) ->
         $params =
           sql: query
-        req = $resource(corsApi + apiRoot + 'datastore_search_sql')
+        req = $resource ckanQueryURL
         req.get($params).$promise
 
       getSchools: ({year, schoolType, moreThan40, subtype}) ->
@@ -150,23 +133,4 @@ angular.module 'edudashAppSrv'
           FROM \"#{getTable(educationLevel, subtype)}\"
           WHERE \"CODE\" = '#{code}'
           ORDER BY \"YEAR_OF_RESULT\" ASC"
-
-      getCsv: (file) ->
-        file = file.replace(/^(http|https):\/\//gm, '')
-        resourceUrl = corsApi + '/' + file
-        $resource(resourceUrl, {},
-          getDataSet: {
-            method: 'GET'
-            isArray: false
-            headers:
-              'Content-Type': 'text/csv; charset=utf-8'
-            responseType: 'text'
-            transformResponse: (data, headers) ->
-              #$log.debug 'csv raw data'
-              result = CsvParser.parseToJson data
-              #$log.debug result
-              result
-          }
-        )
-
   ]

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -197,6 +197,11 @@ h1 {
     margin-right: auto;
 }
 
+.position {
+  position: relative;
+  display: block;
+}
+
 table.schools {
     table-layout: fixed;
     width: 95%;
@@ -763,7 +768,7 @@ table.districts p {
   height: 80px;
 }
 
-#spinner {
+.loading.ajax-loader {
   position:absolute;
   top:0;
   left:0;

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -215,9 +215,10 @@
             </div>
             <div class="container-fluid" ng-if="rankBy==='improvement'">
               <school-list
+                  class="position"
                   list-title="{{'chart.top.most-improved-schools' | translate}}"
                   type="good"
-                  schools="rankedBy"
+                  dataset="rankedBy"
                   click="select"
                   hover="hover"
                   unHover="unHover"
@@ -228,9 +229,10 @@
             </div>
             <div class="container-fluid" ng-if="rankBy==='performance'">
               <school-list
+                  class="position"
                   list-title="{{'chart.top.best-performing-schools' | translate}}"
                   type="good"
-                  schools="rankedBy"
+                  dataset="rankedBy"
                   click="select"
                   hover="hover"
                   unHover="unHover"
@@ -253,9 +255,10 @@
             </div>
             <div class="container-fluid">
               <school-list
+                  class="position"
                   list-title="{{'chart.top.more-than-40-'+(moreThan40?'YES':'NO') | translate}}"
                   type="good"
-                  schools="rankedBy"
+                  dataset="rankedBy"
                   click="select"
                   hover="hover"
                   unHover="unHover"


### PR DESCRIPTION
This branch splits the main download into two requests which each get half of the properties for the schools. It It does enable the content to be downloaded more quickly (just under 2x for me), but CKAN takes more than 2X longer to process each request, so for me it is a little slower. On very bad connections it should be a bit faster.

If there is a way to solve this in CKAN we might be able to get another performance win with this. It could be an issue with Python on CKAN, since python is single-threaded, so it can't process both requests at the same time.

Depending on how the application is deployed, maybe we can get two or more python processes running to speed it up?
