### PR TITLE
Hack around a bug in chrome/v8's JS optimizer

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -96,6 +96,10 @@
       $('select').select2();
     </script>
 
+    <!-- Monkey-patch a leaflet function that is broken on chrome by the
+         optimizing compiler. DO NOT REMOVE probably. -->
+    <script src="scripts/hacks.js"></script>
+
     <!-- build:js({.tmp,app}) scripts/scripts.js -->
     <script src="scripts/app.js"></script>
 

--- a/app/scripts/hacks.js
+++ b/app/scripts/hacks.js
@@ -1,0 +1,41 @@
+L.Map.include((window.chrome === undefined ) ? {} : {  // this bug only affects Chrome/chromium
+  fire: function (type, data) { // (String[, Object])
+    if (!this.hasEventListeners(type)) {
+      return this;
+    }
+
+    var event = L.Util.extend({}, data, { type: type, target: this });
+
+    var events = this._leaflet_events,  // MONKEY-PATCH CHANGE: hard-code to scoped value
+        listeners, i, len, typeIndex, contextId;
+
+    if (events[type]) {
+      // make sure adding/removing listeners inside other listeners won't cause infinite loop
+      listeners = events[type].slice();
+
+      for (i = 0, len = listeners.length; i < len; i++) {
+        listeners[i].action.call(listeners[i].context, event);
+      }
+    }
+
+    // fire event for the context-indexed listeners as well
+    typeIndex = events[type + '_idx'];
+
+    for (contextId in typeIndex) {
+      (function() {  // MONKEY-PATCH CHANGE: wrapping this loop body in an
+                     // anonymous function prevents the bug
+                     // Uncaught TypeError: Cannot read property 'slice' of undefined
+                     // that comes from the following line:
+        listeners = typeIndex[contextId].slice();
+      })(); // END MONKEY-PATCH CHANGE
+
+      if (listeners) {
+        for (i = 0, len = listeners.length; i < len; i++) {
+          listeners[i].action.call(listeners[i].context, event);
+        }
+      }
+    }
+
+    return this;
+  }
+});


### PR DESCRIPTION
We were getting
`Uncaught TypeError: Cannot read property 'slice' of undefined`
from the `_zoomEnd` handler used internally by leaflet when the map was
zoomed by any means, about 50% of the time.

The impact was rendering errors and semi-broken interactivity of the
map. Zoom still worked but click-drag to pan did not.

Through debugging, it was determined that the cause is some issue in
the javascript compiler's optimizer. Placing a `debugger;` statement
would prevent the bug from occurring, but doing so also disables the
optimizer for that function. The optimizer-bug hypothesis was validated
by adding other code known to disable optimization of javascript
functions: an empty `try {} catch(e) {}` made the bug go away, as did a
`with({});` statement anywhere in the function.

Finally, through experimentation it was discovered that simply moving
the erroring expression into an inline anonymous function also made the
bug go away. This is the fix contained in this commit, which
monkey-patches itself into leaflet if it detects itself running on
chrome.

It would be nice to reduce the original bug to a minimal setup that
exhibits the issue in order to prepare a bug report for the chrome
team, but this has yet to be completed.
