### PR TITLE
Update detailedPolys if schools data changes

### DIFF
--- a/app/scripts/controllers/dashboard.coffee
+++ b/app/scripts/controllers/dashboard.coffee
@@ -124,11 +124,11 @@ angular.module('edudashAppCtrl').controller 'DashboardCtrl', [
                 )
 
         watchCompute 'detailedPolys',
-          dependencies: ['polygons', 'polyType', 'allSchools', 'schoolType']
+          dependencies: ['polygons', 'allSchools', 'polyType', 'schoolType']
           waitForPromise: true
-          computer: ([polygons, polyType, allSchools, schoolType], [oldPolys]) ->
+          computer: ([polygons, allSchools, polyType, schoolType], [oldPolys, oldSchools]) ->
             $q (resolve, reject) ->
-              unless polygons? and allSchools? and polygons != oldPolys
+              unless polygons? and allSchools? and (polygons != oldPolys or allSchools != oldSchools)
                 resolve null
               else
                 $q.all


### PR DESCRIPTION
Before it would only update if the polygons changed, so changing the year would
destroy the layer without replacing it with a new one.

Now, detailedPolys updates as long as both polygon data and schools data are
presentm, and one of those two has updated.
