### PR TITLE
Order search results by startswith

### DIFF
--- a/app/scripts/services/api.coffee
+++ b/app/scripts/services/api.coffee
@@ -120,6 +120,12 @@ angular.module 'edudashAppSrv'
               (\"NAME\" ILIKE '%#{query}%'
                 OR \"CODE\" ILIKE '%#{query}%')
             AND \"YEAR_OF_RESULT\" = #{year}
+          ORDER BY
+            CASE
+              WHEN \"NAME\" ILIKE '#{query}%' THEN 1
+              WHEN \"CODE\" ILIKE '#{query}%' THEN 2
+              ELSE 3
+            END
           LIMIT 10"
 
       getYears: (educationLevel, subtype) ->


### PR DESCRIPTION
Fixes issue noticed by @gkalvatcheva, where a school's exact name might not return it because it's ordered out of the search result.

![order-by](https://cloud.githubusercontent.com/assets/205128/9883258/1b545696-5ba7-11e5-8719-36547f0b0252.png)
