### PR TITLE
Passrate flyout colour

### DIFF
--- a/app/scripts/services/brackets.coffee
+++ b/app/scripts/services/brackets.coffee
@@ -9,23 +9,23 @@
 ###
 angular.module('edudashAppSrv').service 'bracketsSrv', ($q, utils) ->
 
-  AVG_GPA_MIN: 3
-  AVG_GPA_MAX: 4.2
-  PASS_RATE_MIN: 0
-  PASS_RATE_MID1: 40
-  PASS_RATE_MID2: 60
-  PASS_RATE_MAX: 100
-  PUPIL_TEACHER_RATIO_MIN: 0
-  PUPIL_TEACHER_RATIO_MID1: 35
-  PUPIL_TEACHER_RATIO_MID2: 50
-  PUPIL_TEACHER_RATIO_MAX: 100
+  AVG_GPA_MIN = 3
+  AVG_GPA_MAX = 4.2
+  PASS_RATE_MIN = 0
+  PASS_RATE_MID1 = 40
+  PASS_RATE_MID2 = 60
+  PASS_RATE_MAX = 100
+  PUPIL_TEACHER_RATIO_MIN = 0
+  PUPIL_TEACHER_RATIO_MID1 = 35
+  PUPIL_TEACHER_RATIO_MID2 = 50
+  PUPIL_TEACHER_RATIO_MAX = 100
 
   getBrackets: (metric) ->
     switch metric
       when 'AVG_MARK' then throw new Error "AVG_MARK shall not be bracket"
-      when 'AVG_GPA' then [this.AVG_GPA_MIN, this.AVG_GPA_MAX]
-      when 'PASS_RATE' then [this.PASS_RATE_MIN, this.PASS_RATE_MID1, this.PASS_RATE_MID2, this.PASS_RATE_MAX]
-      when 'PUPIL_TEACHER_RATIO' then [this.PUPIL_TEACHER_RATIO_MIN, this.PUPIL_TEACHER_RATIO_MID1, this.PUPIL_TEACHER_RATIO_MID2, this.PUPIL_TEACHER_RATIO_MAX]
+      when 'AVG_GPA' then [AVG_GPA_MIN, AVG_GPA_MAX]
+      when 'PASS_RATE' then [PASS_RATE_MIN, PASS_RATE_MID1, PASS_RATE_MID2, PASS_RATE_MAX]
+      when 'PUPIL_TEACHER_RATIO' then [PUPIL_TEACHER_RATIO_MIN, PUPIL_TEACHER_RATIO_MID1, PUPIL_TEACHER_RATIO_MID2, PUPIL_TEACHER_RATIO_MAX]
 
   getBracket: (val, metric) ->
     unless typeof val in ['number', 'undefined', 'string']
@@ -41,9 +41,9 @@ angular.module('edudashAppSrv').service 'bracketsSrv', ($q, utils) ->
 
         # According to Mark we don't have to validate GPA ranges
         when 'AVG_GPA' then switch
-          when val <= this.AVG_GPA_MIN then 'GOOD'
-          when this.AVG_GPA_MIN < val <= this.AVG_GPA_MAX then 'MEDIUM'
-          when val > this.AVG_GPA_MAX then 'POOR'  # what's the upper limit?
+          when val <= AVG_GPA_MIN then 'GOOD'
+          when AVG_GPA_MIN < val <= AVG_GPA_MAX then 'MEDIUM'
+          when val > AVG_GPA_MAX then 'POOR'  # what's the upper limit?
 
         when 'CHANGE_PREVIOUS_YEAR' then switch
           when val < 0 then 'POOR'
@@ -62,15 +62,15 @@ angular.module('edudashAppSrv').service 'bracketsSrv', ($q, utils) ->
           # `when`s are exhaustive: tested typeof === number and !isNaN
 
         when 'PASS_RATE' then switch
-          when this.PASS_RATE_MIN <= val < this.PASS_RATE_MID1 then 'POOR'
-          when this.PASS_RATE_MID1 <= val <= this.PASS_RATE_MID2 then 'MEDIUM'
-          when this.PASS_RATE_MID2 < val <= this.PASS_RATE_MAX then 'GOOD'
+          when PASS_RATE_MIN <= val < PASS_RATE_MID1 then 'POOR'
+          when PASS_RATE_MID1 <= val <= PASS_RATE_MID2 then 'MEDIUM'
+          when PASS_RATE_MID2 < val <= PASS_RATE_MAX then 'GOOD'
           else 'UNKNOWN'
 
         when 'PUPIL_TEACHER_RATIO' then switch
-          when this.PUPIL_TEACHER_RATIO_MIN < val < this.PUPIL_TEACHER_RATIO_MID1 then 'GOOD'
-          when this.PUPIL_TEACHER_RATIO_MID1 <= val <= this.PUPIL_TEACHER_RATIO_MID2 then 'MEDIUM'
-          when val > this.PUPIL_TEACHER_RATIO_MID2 then 'POOR'
+          when PUPIL_TEACHER_RATIO_MIN < val < PUPIL_TEACHER_RATIO_MID1 then 'GOOD'
+          when PUPIL_TEACHER_RATIO_MID1 <= val <= PUPIL_TEACHER_RATIO_MID2 then 'MEDIUM'
+          when val > PUPIL_TEACHER_RATIO_MID2 then 'POOR'
           else 'UNKNOWN'
 
         else throw new Error "Unknown metric: '#{metric}'"

--- a/test/spec/services/brackets.coffee
+++ b/test/spec/services/brackets.coffee
@@ -17,124 +17,132 @@ describe 'watchComputeSrv', ->
     $q = _$q_
     $rootScope = _$rootScope_
 
-  it 'should validate getMetric parameters', ->
-    expect -> b.getVisMetric()
-      .toThrow new Error "Unknown vis mode 'undefined'"
-    expect -> b.getVisMetric 'bad visMode'
-      .toThrow new Error "Unknown vis mode 'bad visMode'"
 
-  it 'should provide the correct metric from getMetric', ->
-    # exhaustive check because we can
-    expect b.getVisMetric 'passrate'
-      .toEqual 'PASS_RATE'
-    expect b.getVisMetric 'ptratio'
-      .toEqual 'PUPIL_TEACHER_RATIO'
-    expect b.getVisMetric 'gpa'
-      .toEqual 'AVG_GPA'
+  describe 'getVisMetric', ->
+    it 'should validate parameters', ->
+      expect -> b.getVisMetric()
+        .toThrow new Error "Unknown vis mode 'undefined'"
+      expect -> b.getVisMetric 'bad visMode'
+        .toThrow new Error "Unknown vis mode 'bad visMode'"
 
-  it 'should validate getSortMetric parameters', ->
-    expect -> b.getSortMetric()
-      .toThrow new Error "Unknown school type 'undefined'"
-    expect -> b.getSortMetric 'bad school type'
-      .toThrow new Error "Unknown school type 'bad school type'"
-    expect -> b.getSortMetric 'primary'
-      .toThrow new Error "Unknown criteria 'undefined'"
-    expect -> b.getSortMetric 'primary', 'bad criteria'
-      .toThrow new Error "Unknown criteria 'bad criteria'"
-
-  it 'should provide the correct metric from getSortMetric', ->
-    # exhaustive check because we can
-    expect b.getSortMetric 'primary', 'performance'
-      .toEqual ['AVG_MARK', 'DESC']
-    expect b.getSortMetric 'primary', 'improvement'
-      .toEqual ['CHANGE_PREVIOUS_YEAR', 'DESC']
-    expect b.getSortMetric 'secondary', 'performance'
-      .toEqual ['AVG_GPA', 'ASC']
-    expect b.getSortMetric 'secondary', 'improvement'
-      .toEqual ['CHANGE_PREVIOUS_YEAR_GPA', 'ASC']
-
-  it 'should validate getBracket parameters', ->
-    expect(b.getBracket 'x', 'AVG_MARK').toEqual 'UNKNOWN'
-#    expect -> b.getBracket 'z'
-#      .toThrow new Error "val must be a number. Got: 'z' which is 'string'"
-    expect -> b.getBracket 1
-      .toThrow new Error "Unknown metric: 'undefined'"
-    expect -> b.getBracket 1, 'not a metric'
-      .toThrow new Error "Unknown metric: 'not a metric'"
-
-  it 'should return UNKNOWN for NaN', ->
-    expect(b.getBracket NaN, 'AVG_MARK').toEqual 'UNKNOWN'
-    expect(b.getBracket NaN, 'AVG_GPA').toEqual 'UNKNOWN'
-    expect(b.getBracket NaN, 'CHANGE_PREVIOUS_YEAR').toEqual 'UNKNOWN'
-    expect(b.getBracket NaN, 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'UNKNOWN'
-    expect(b.getBracket undefined, 'AVG_MARK').toEqual 'UNKNOWN'
-
-  it 'AVG_MARK ranges', ->
-    expect -> b.getBracket 0,  'AVG_MARK'
-      .toThrow new Error "AVG_MARK shall not be bracket"
-    expect -> b.getBracket -1, 'AVG_MARK'
-      .toThrow new Error "AVG_MARK shall not be bracket"
-    expect -> b.getBracket 1,  'AVG_MARK'
-      .toThrow new Error "AVG_MARK shall not be bracket"
-
-  it 'AVG_GPA ranges', ->
-    expect(b.getBracket 1,  'AVG_GPA').toEqual 'GOOD'
-    expect(b.getBracket 3,  'AVG_GPA').toEqual 'GOOD'
-    expect(b.getBracket 3.1,'AVG_GPA').toEqual 'MEDIUM'
-    expect(b.getBracket 4.2,'AVG_GPA').toEqual 'MEDIUM'
-    expect(b.getBracket 4.3,'AVG_GPA').toEqual 'POOR'
-    expect(b.getBracket 5,  'AVG_GPA').toEqual 'POOR'
+    it 'should provide the correct metric', ->
+      # exhaustive check because we can
+      expect b.getVisMetric 'passrate'
+        .toEqual 'PASS_RATE'
+      expect b.getVisMetric 'ptratio'
+        .toEqual 'PUPIL_TEACHER_RATIO'
+      expect b.getVisMetric 'gpa'
+        .toEqual 'AVG_GPA'
 
 
-  it 'CHANGE_PREVIOUS_YEAR ranges', ->
-    # TODO: can we sanity-check some maximum changes for UNDEFINED?
-    expect(b.getBracket -1,'CHANGE_PREVIOUS_YEAR').toEqual 'POOR'
-    expect(b.getBracket 0, 'CHANGE_PREVIOUS_YEAR').toEqual 'MEDIUM'
-    expect(b.getBracket 1, 'CHANGE_PREVIOUS_YEAR').toEqual 'GOOD'
+  describe 'getSortMetric', ->
+    it 'should validate parameters', ->
+      expect -> b.getSortMetric()
+        .toThrow new Error "Unknown school type 'undefined'"
+      expect -> b.getSortMetric 'bad school type'
+        .toThrow new Error "Unknown school type 'bad school type'"
+      expect -> b.getSortMetric 'primary'
+        .toThrow new Error "Unknown criteria 'undefined'"
+      expect -> b.getSortMetric 'primary', 'bad criteria'
+        .toThrow new Error "Unknown criteria 'bad criteria'"
 
-  it 'CHANGE_PREVIOUS_YEAR_PASSRATE ranges', ->
-    # TODO: can we sanity-check some maximum changes for UNDEFINED?
-    expect(b.getBracket -1,'CHANGE_PREVIOUS_YEAR_PASSRATE').toEqual 'POOR'
-    expect(b.getBracket 0, 'CHANGE_PREVIOUS_YEAR_PASSRATE').toEqual 'MEDIUM'
-    expect(b.getBracket 1, 'CHANGE_PREVIOUS_YEAR_PASSRATE').toEqual 'GOOD'
+    it 'should provide the correct metric', ->
+      # exhaustive check because we can
+      expect b.getSortMetric 'primary', 'performance'
+        .toEqual ['AVG_MARK', 'DESC']
+      expect b.getSortMetric 'primary', 'improvement'
+        .toEqual ['CHANGE_PREVIOUS_YEAR', 'DESC']
+      expect b.getSortMetric 'secondary', 'performance'
+        .toEqual ['AVG_GPA', 'ASC']
+      expect b.getSortMetric 'secondary', 'improvement'
+        .toEqual ['CHANGE_PREVIOUS_YEAR_GPA', 'ASC']
 
-  it 'CHANGE_PREVIOUS_YEAR_GPA ranges', ->
-    # TODO: can we sanity-check some maximum changes for UNDEFINED?
-    expect(b.getBracket -1,'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'GOOD'
-    expect(b.getBracket 0, 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'MEDIUM'
-    expect(b.getBracket 1, 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'POOR'
-    expect(b.getBracket '-1','CHANGE_PREVIOUS_YEAR_GPA').toEqual 'GOOD'
-    expect(b.getBracket '0', 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'MEDIUM'
-    expect(b.getBracket '1', 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'POOR'
+  describe 'getBracket', ->
+    it 'should validate parameters', ->
+      expect(b.getBracket 'x', 'AVG_MARK').toEqual 'UNKNOWN'
+  #    expect -> b.getBracket 'z'
+  #      .toThrow new Error "val must be a number. Got: 'z' which is 'string'"
+      expect -> b.getBracket 1
+        .toThrow new Error "Unknown metric: 'undefined'"
+      expect -> b.getBracket 1, 'not a metric'
+        .toThrow new Error "Unknown metric: 'not a metric'"
 
-  it 'PASS_RATE ranges', ->
-    expect(b.getBracket -1, 'PASS_RATE').toEqual 'UNKNOWN'
-    expect(b.getBracket 0,  'PASS_RATE').toEqual 'POOR'
-    expect(b.getBracket 39, 'PASS_RATE').toEqual 'POOR'
-    expect(b.getBracket 40, 'PASS_RATE').toEqual 'MEDIUM'
-    expect(b.getBracket 60, 'PASS_RATE').toEqual 'MEDIUM'
-    expect(b.getBracket 61, 'PASS_RATE').toEqual 'GOOD'
-    expect(b.getBracket 100,'PASS_RATE').toEqual 'GOOD'
-    expect(b.getBracket 101,'PASS_RATE').toEqual 'UNKNOWN'
+    it 'should return UNKNOWN for NaN', ->
+      expect(b.getBracket NaN, 'AVG_MARK').toEqual 'UNKNOWN'
+      expect(b.getBracket NaN, 'AVG_GPA').toEqual 'UNKNOWN'
+      expect(b.getBracket NaN, 'CHANGE_PREVIOUS_YEAR').toEqual 'UNKNOWN'
+      expect(b.getBracket NaN, 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'UNKNOWN'
+      expect(b.getBracket undefined, 'AVG_MARK').toEqual 'UNKNOWN'
 
-  it 'PUPIL_TEACHER_RATIO ranges', ->
-    expect(b.getBracket 0, 'PUPIL_TEACHER_RATIO').toEqual 'UNKNOWN'
-    expect(b.getBracket 1,  'PUPIL_TEACHER_RATIO').toEqual 'GOOD'
-    expect(b.getBracket 34, 'PUPIL_TEACHER_RATIO').toEqual 'GOOD'
-    expect(b.getBracket 35, 'PUPIL_TEACHER_RATIO').toEqual 'MEDIUM'
-    expect(b.getBracket 50, 'PUPIL_TEACHER_RATIO').toEqual 'MEDIUM'
-    expect(b.getBracket 51, 'PUPIL_TEACHER_RATIO').toEqual 'POOR'
-    expect(b.getBracket 100,'PUPIL_TEACHER_RATIO').toEqual 'POOR'
+    it 'AVG_MARK ranges', ->
+      expect -> b.getBracket 0,  'AVG_MARK'
+        .toThrow new Error "AVG_MARK shall not be bracket"
+      expect -> b.getBracket -1, 'AVG_MARK'
+        .toThrow new Error "AVG_MARK shall not be bracket"
+      expect -> b.getBracket 1,  'AVG_MARK'
+        .toThrow new Error "AVG_MARK shall not be bracket"
 
-  it 'getRank by school', ->
-    expect(b.getRank 'primary').toEqual ['AVG_MARK', 'DESC']
-    expect(b.getRank 'secondary').toEqual ['AVG_GPA', 'ASC']
+    it 'AVG_GPA ranges', ->
+      expect(b.getBracket 1,  'AVG_GPA').toEqual 'GOOD'
+      expect(b.getBracket 3,  'AVG_GPA').toEqual 'GOOD'
+      expect(b.getBracket 3.1,'AVG_GPA').toEqual 'MEDIUM'
+      expect(b.getBracket 4.2,'AVG_GPA').toEqual 'MEDIUM'
+      expect(b.getBracket 4.3,'AVG_GPA').toEqual 'POOR'
+      expect(b.getBracket 5,  'AVG_GPA').toEqual 'POOR'
 
-  it 'should validate getRank parameter', ->
-    expect -> b.getRank 'z'
-      .toThrow new Error "Unknown school type 'z'"
-    expect -> b.getRank undefined
-      .toThrow new Error "Unknown school type 'undefined'"
+
+    it 'CHANGE_PREVIOUS_YEAR ranges', ->
+      # TODO: can we sanity-check some maximum changes for UNDEFINED?
+      expect(b.getBracket -1,'CHANGE_PREVIOUS_YEAR').toEqual 'POOR'
+      expect(b.getBracket 0, 'CHANGE_PREVIOUS_YEAR').toEqual 'MEDIUM'
+      expect(b.getBracket 1, 'CHANGE_PREVIOUS_YEAR').toEqual 'GOOD'
+
+    it 'CHANGE_PREVIOUS_YEAR_PASSRATE ranges', ->
+      # TODO: can we sanity-check some maximum changes for UNDEFINED?
+      expect(b.getBracket -1,'CHANGE_PREVIOUS_YEAR_PASSRATE').toEqual 'POOR'
+      expect(b.getBracket 0, 'CHANGE_PREVIOUS_YEAR_PASSRATE').toEqual 'MEDIUM'
+      expect(b.getBracket 1, 'CHANGE_PREVIOUS_YEAR_PASSRATE').toEqual 'GOOD'
+
+    it 'CHANGE_PREVIOUS_YEAR_GPA ranges', ->
+      # TODO: can we sanity-check some maximum changes for UNDEFINED?
+      expect(b.getBracket -1,'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'GOOD'
+      expect(b.getBracket 0, 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'MEDIUM'
+      expect(b.getBracket 1, 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'POOR'
+      expect(b.getBracket '-1','CHANGE_PREVIOUS_YEAR_GPA').toEqual 'GOOD'
+      expect(b.getBracket '0', 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'MEDIUM'
+      expect(b.getBracket '1', 'CHANGE_PREVIOUS_YEAR_GPA').toEqual 'POOR'
+
+    it 'PASS_RATE ranges', ->
+      expect(b.getBracket -1, 'PASS_RATE').toEqual 'UNKNOWN'
+      expect(b.getBracket 0,  'PASS_RATE').toEqual 'POOR'
+      expect(b.getBracket 39, 'PASS_RATE').toEqual 'POOR'
+      expect(b.getBracket 40, 'PASS_RATE').toEqual 'MEDIUM'
+      expect(b.getBracket 60, 'PASS_RATE').toEqual 'MEDIUM'
+      expect(b.getBracket 61, 'PASS_RATE').toEqual 'GOOD'
+      expect(b.getBracket 100,'PASS_RATE').toEqual 'GOOD'
+      expect(b.getBracket 101,'PASS_RATE').toEqual 'UNKNOWN'
+
+    it 'PUPIL_TEACHER_RATIO ranges', ->
+      expect(b.getBracket 0, 'PUPIL_TEACHER_RATIO').toEqual 'UNKNOWN'
+      expect(b.getBracket 1,  'PUPIL_TEACHER_RATIO').toEqual 'GOOD'
+      expect(b.getBracket 34, 'PUPIL_TEACHER_RATIO').toEqual 'GOOD'
+      expect(b.getBracket 35, 'PUPIL_TEACHER_RATIO').toEqual 'MEDIUM'
+      expect(b.getBracket 50, 'PUPIL_TEACHER_RATIO').toEqual 'MEDIUM'
+      expect(b.getBracket 51, 'PUPIL_TEACHER_RATIO').toEqual 'POOR'
+      expect(b.getBracket 100,'PUPIL_TEACHER_RATIO').toEqual 'POOR'
+
+
+  describe 'getRank', ->
+    it 'should rank by school', ->
+      expect(b.getRank 'primary').toEqual ['AVG_MARK', 'DESC']
+      expect(b.getRank 'secondary').toEqual ['AVG_GPA', 'ASC']
+
+    it 'should validate parameters', ->
+      expect -> b.getRank 'z'
+        .toThrow new Error "Unknown school type 'z'"
+      expect -> b.getRank undefined
+        .toThrow new Error "Unknown school type 'undefined'"
+
 
   describe 'hasBadge', ->
     # async helper...

--- a/test/spec/services/brackets.coffee
+++ b/test/spec/services/brackets.coffee
@@ -131,6 +131,10 @@ describe 'watchComputeSrv', ->
       expect(b.getBracket 51, 'PUPIL_TEACHER_RATIO').toEqual 'POOR'
       expect(b.getBracket 100,'PUPIL_TEACHER_RATIO').toEqual 'POOR'
 
+    it 'Should not depend on `this` context (regression)', ->
+      alias = b.getBracket
+      expect(alias 1, 'PASS_RATE').toEqual 'POOR'
+
 
   describe 'getRank', ->
     it 'should rank by school', ->


### PR DESCRIPTION
Restores colouring of the passrate value in the schools flyout.

The FlyoutNumber directive was passing the `getBracket` function directly to its view, so it was being called as a function directly, `getBracket()` instead of being dereferenced `bracketsSrv.getBracket()`, so it lost the `this` context, breaking the function.

This change makes the constants in `bracketsSrv` scope variables, instead of properties on the service. So now they are accessed from the regular javascript scope instead of via eg., `this.PASS_RATE_MIN`.

A regression test is included.
